### PR TITLE
More idiomatic Rx implementation

### DIFF
--- a/src/TplTipsAndTricks/ProcessTasksByCompletion/Sample.cs
+++ b/src/TplTipsAndTricks/ProcessTasksByCompletion/Sample.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
@@ -156,6 +157,19 @@ namespace TplTipsAndTricks.ProcessTasksByCompletion
             {
                 ProcessWeather(obj.City, obj.Weather);
             }
+        }
+
+        [Test]
+        public Task ProcessUsingRx()
+        {
+            var cities = new[] { "Moscow", "Seattle", "New York" };
+            return cities
+                .ToObservable()
+                .SelectMany(
+                    (city, cancellation) => GetWeatherForAsync(city),
+                    (city, weather) => new { City = city, Weather = weather })
+                //.ObserveOn(Scheduler.CurrentThread) //optional
+                .ForEachAsync(result => ProcessWeather(result.City, result.Weather));
         }
 
 [Test]


### PR DESCRIPTION
I noticed the attempt to create SelectMany implementation with limited concurrency, and this implementation is lacking in that regard, but otherwise looks much cleaner _to me_.
And obviously there is no guarantee on which thread the observable will surface, but it's easily controllable with ObserveOn.
In general though I would not approach this kind of problem with Rx because when you're thinking "I need to do several things in parallel", it's usually not the best tool for the job. I personally happen to implement similar pipeline in current project and I chose Rx for the sole reason that I needed to publish progress events for each item in the pipeline. Rx helped with that. But identity map for items, retries and error handling in general were kind of in conflict with _Rx way_.
